### PR TITLE
Optimize some Array.prototype methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,15 @@ var path = require("path"),
 
     objectify = require("./src/objectify");
 
+function transform(source) {
+    return falafel({
+        source      : source,
+        ecmaVersion : 6
+    }, objectify);
+}
+
 module.exports = function(file) {
-    var text = "";
+    var source = "";
 
     if(path.extname(file) !== ".js") {
         return through();
@@ -16,18 +23,16 @@ module.exports = function(file) {
 
     return through(
         function(buf, encoding, done) {
-            text += buf;
+            source += buf;
 
             done();
         },
         function(done) {
-            this.push(falafel(text, objectify).toString());
+            this.push(transform(source).toString());
 
             done();
         }
     );
 };
 
-module.exports.objectify = function(src) {
-    return falafel(src, objectify);
-};
+module.exports.objectify = transform;

--- a/package.json
+++ b/package.json
@@ -7,13 +7,17 @@
   "scripts": {
     "test": "npm run lint && npm run tape",
     "lint": "eslint .",
-    "coverage": "istanbul test --print both ./node_modules/tape/bin/tape -- tape test/*.js",
+    "cover": "istanbul test --print both ./node_modules/tape/bin/tape -- tape test/*.js",
     "tape": "tape test/*.js"
   },
   "author": "Pat Cavit <pcavit@arena.net>",
   "repository": "tivac/mithril-objectify",
   "license": "MIT",
-  "keywords": [ "mithril", "optimization", "ast" ],
+  "keywords": [
+    "mithril",
+    "optimization",
+    "ast"
+  ],
   "dependencies": {
     "falafel": "^1.2.0",
     "through2": "^2.0.0"
@@ -21,218 +25,20 @@
   "devDependencies": {
     "concat-stream": "^1.5.0",
     "eslint": "^1.7.3",
+    "eslint-config-arenanet": "^1.0.2",
     "istanbul": "^0.4.0",
     "mithril": "^0.2.0",
     "tape": "^4.2.0"
   },
   "eslintConfig": {
+    "extends": "arenanet",
     "ecmaFeatures": {
-      "templateStrings": true
+      "templateStrings": true,
+      "arrowFunctions": true
     },
     "env": {
-      "node": true
-    },
-    "rules": {
-      "comma-dangle": 2,
-      "no-cond-assign": 2,
-      "no-console": 1,
-      "no-constant-condition": 2,
-      "no-control-regex": 0,
-      "no-debugger": 1,
-      "no-dupe-keys": 2,
-      "no-empty": 1,
-      "no-empty-character-class": 1,
-      "no-ex-assign": 2,
-      "no-extra-boolean-cast": 1,
-      "no-extra-parens": 0,
-      "no-extra-semi": 2,
-      "no-func-assign": 1,
-      "no-inner-declarations": 0,
-      "no-invalid-regexp": 0,
-      "no-irregular-whitespace": 1,
-      "no-negated-in-lhs": 1,
-      "no-obj-calls": 0,
-      "no-regex-spaces": 1,
-      "no-reserved-keys": 0,
-      "no-sparse-arrays": 1,
-      "no-unreachable": 2,
-      "use-isnan": 2,
-      "valid-jsdoc": 0,
-      "valid-typeof": 2,
-      "block-scoped-var": 0,
-      "complexity": [
-        2,
-        10
-      ],
-      "consistent-return": 2,
-      "curly": 2,
-      "default-case": 1,
-      "dot-notation": 2,
-      "eqeqeq": 2,
-      "guard-for-in": 0,
-      "no-alert": 1,
-      "no-caller": 2,
-      "no-div-regex": 1,
-      "no-else-return": 2,
-      "no-empty-label": 2,
-      "no-eq-null": 0,
-      "no-eval": 2,
-      "no-extend-native": 2,
-      "no-extra-bind": 2,
-      "no-fallthrough": 1,
-      "no-floating-decimal": 2,
-      "no-implied-eval": 2,
-      "no-iterator": 2,
-      "no-labels": 2,
-      "no-lone-blocks": 2,
-      "no-loop-func": 1,
-      "no-multi-spaces": [
-        1,
-        {
-          "exceptions": {
-            "AssignmentExpression": true,
-            "Property": true,
-            "VariableDeclarator": true
-          }
-        }
-      ],
-      "no-multi-str": 2,
-      "no-native-reassign": 2,
-      "no-new": 0,
-      "no-new-func": 0,
-      "no-new-wrappers": 2,
-      "no-octal": 2,
-      "no-octal-escape": 2,
-      "no-process-env": 0,
-      "no-proto": 2,
-      "no-redeclare": 2,
-      "no-return-assign": 2,
-      "no-script-url": 2,
-      "no-self-compare": 2,
-      "no-sequences": 2,
-      "no-unused-expressions": 2,
-      "no-void": 2,
-      "no-warning-comments": 0,
-      "no-with": 2,
-      "radix": 2,
-      "vars-on-top": 2,
-      "wrap-iife": 2,
-      "yoda": 2,
-      "strict": 0,
-      "no-catch-shadow": 2,
-      "no-delete-var": 2,
-      "no-label-var": 2,
-      "no-shadow": 2,
-      "no-shadow-restricted-names": 2,
-      "no-undef": 2,
-      "no-undef-init": 2,
-      "no-undefined": 0,
-      "no-unused-vars": 1,
-      "no-use-before-define": 2,
-      "handle-callback-err": 0,
-      "no-mixed-requires": 0,
-      "no-new-require": 0,
-      "no-path-concat": 0,
-      "no-process-exit": 0,
-      "no-restricted-modules": 0,
-      "no-sync": 0,
-      "brace-style": 2,
-      "camelcase": [
-        2,
-        {
-          "properties": "never"
-        }
-      ],
-      "comma-spacing": 2,
-      "comma-style": [
-        2,
-        "last"
-      ],
-      "consistent-this": [
-        2,
-        "self"
-      ],
-      "eol-last": 1,
-      "func-names": 0,
-      "func-style": [
-        1,
-        "declaration"
-      ],
-      "key-spacing": [
-        2,
-        {
-          "beforeColon": true,
-          "afterColon": true,
-          "align": "colon"
-        }
-      ],
-      "max-nested-callbacks": 0,
-      "new-cap": 2,
-      "new-parens": 2,
-      "no-array-constructor": 2,
-      "no-inline-comments": 0,
-      "no-lonely-if": 2,
-      "no-mixed-spaces-and-tabs": 2,
-      "no-multiple-empty-lines": 1,
-      "no-nested-ternary": 2,
-      "no-new-object": 2,
-      "semi-spacing": [
-        1,
-        {
-          "before": false,
-          "after": true
-        }
-      ],
-      "no-spaced-func": 2,
-      "no-ternary": 0,
-      "no-trailing-spaces": 0,
-      "no-underscore-dangle": 0,
-      "no-wrap-func": 0,
-      "one-var": 0,
-      "operator-assignment": 0,
-      "padded-blocks": [
-        1,
-        "never"
-      ],
-      "quote-props": [
-        2,
-        "as-needed"
-      ],
-      "quotes": [
-        2,
-        "double"
-      ],
-      "semi": 2,
-      "sort-vars": 0,
-      "space-before-function-paren": [
-        2,
-        "never"
-      ],
-      "space-after-keywords": [
-        2,
-        "never"
-      ],
-      "space-before-blocks": [
-        2,
-        "always"
-      ],
-      "object-curly-spacing": [
-        2,
-        "always"
-      ],
-      "array-bracket-spacing": [
-        2,
-        "always"
-      ],
-      "space-in-parens": 0,
-      "space-infix-ops": 2,
-      "space-return-throw-case": 2,
-      "space-unary-ops": 0,
-      "spaced-comment": [
-        1,
-        "always"
-      ],
-      "wrap-regex": 0
+      "node": true,
+      "mocha": true
     }
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -84,6 +84,36 @@ test("Non-string attr values", function(t) {
     t.end();
 });
 
+test("Array.prototype methods", function(t) {
+    /* eslint brace-style:0, no-unused-expressions:0 */
+    t.looseEqual(
+        p(`m("div", [ 1, 2 ].map((val) => { val; }))`),
+        m("div", [ 1, 2 ].map((val) => { val; }))
+    );
+
+    t.looseEqual(
+        p(`m("div", [ 1, 2 ].filter((val) => { val === 1; }))`),
+        m("div", [ 1, 2 ].filter((val) => { val === 1; }))
+    );
+
+    t.looseEqual(
+        p(`m("div", [ 1, 2 ].sort())`),
+        m("div", [ 1, 2 ].sort())
+    );
+
+    t.equal(
+        p.objectify(`m("div", [ 1, 2 ].forEach((val) => { val === 1 }))`),
+        `m("div", [ 1, 2 ].forEach((val) => { val === 1 }))`
+    );
+
+    t.equal(
+        p.objectify(`m("div", [ 1, 2 ].some((val) => { val === 1 }))`),
+        `m("div", [ 1, 2 ].some((val) => { val === 1 }))`
+    );
+
+    t.end();
+});
+
 test("Filtering doesn't transform unsafe invocations", function(t) {
     // Ensure that the selector must be literal
     t.equal(
@@ -96,7 +126,7 @@ test("Filtering doesn't transform unsafe invocations", function(t) {
         `m("input" + ".pure-u")`
     );
     
-    // Identifiers can't be resolved at compiel time, so ignore
+    // Identifiers can't be resolved at compile time, so ignore
     t.equal(
         p.objectify(`m(".fooga", identifier)`),
         `m(".fooga", identifier)`


### PR DESCRIPTION
- Not all Array.prototype methods are safe so there's a whitelist to check against, we can only optimize methods that themselves return an array.
- Updated acorn so it's parsing ES6 (which should be fine for all ES5 code as well).
- Using standard ESLint config so it isn't a weird one-off

Fixes #4