### PR TITLE
Fix quoted properties

### DIFF
--- a/src/objectify.js
+++ b/src/objectify.js
@@ -16,7 +16,7 @@ function getClass(node) {
 
     if(node.arguments[1] && node.arguments[1].type === "ObjectExpression") {
         node.arguments[1].properties.some(function(property) {
-            var key = property.key.name;
+            var key = property.key.name || property.key.value;
 
             if(key === "class") {
                 type = "class";
@@ -119,7 +119,7 @@ function parseAttrs(node, out) {
     var className = getClass(node);
 
     node.arguments[1].properties.forEach(function(property) {
-        var key = property.key.name,
+        var key = property.key.name || property.key.value,
             css;
 
         // Class combinations get weird, so handling specially

--- a/test/tests.js
+++ b/test/tests.js
@@ -84,6 +84,16 @@ test("Non-string attr values", function(t) {
     t.end();
 });
 
+test("Quoted properties (issue #6)", function(t) {
+    /* eslint quote-props:0 */
+    t.looseEqual(
+        p(`m("div", { "fooga" : 0 })`),
+        m("div", { "fooga" : 0 })
+    );
+
+    t.end();
+});
+
 test("Array.prototype methods", function(t) {
     /* eslint brace-style:0, no-unused-expressions:0 */
     t.looseEqual(


### PR DESCRIPTION
This reverts commit 7bc837fee92ef792e02a9aa54d72f8351ddccc04.

It turns out this was required to support quoted object properties and there just wasn't a test for it. Yikes!

Added a test for quoted properties so this doesn't happen again, which now bumps coverage to 100%. That seems useful.

Fixes #6