### PR TITLE
Added support for ES6 imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
+
 {
   "name": "mithril-objectify",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Optimize Mithril m() calls into simple JS objects via API, CLI, or Browserify",
   "main": "index.js",
   "bin": "./bin/cli.js",

--- a/src/objectify.js
+++ b/src/objectify.js
@@ -44,9 +44,14 @@ function arrayExpression(node) {
 
 // Check if this is an invocation of m()
 function invocation(node) {
-    return node.type === "CallExpression" &&
-           node.callee.type === "Identifier" &&
-           node.callee.name === "m";
+    return node.type === "CallExpression" && (
+        (node.callee.type === "Identifier" && node.callee.name === "m") ||
+        (node.callee.type === "SequenceExpression" &&
+         node.callee.expressions.length === 2 &&
+         node.callee.expressions[1].type === "MemberExpression" &&
+         node.callee.expressions[1].object.name.startsWith("_mithril")
+        )
+    );
 }
 
 function valid(node) {


### PR DESCRIPTION
So I haven't messed with Browserify transforms before, but these changes fix the issues I was having with ES6 imports per #11. Tests run fine and I was able to build a moderately sized ES6 mithril project without issue.