### PR TITLE
Rollup plugin & exports rework

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,7 @@
 
 var fs = require("fs"),
     
-    objectify = require("../index.js").objectify;
+    transform = require("../");
 
 fs.readFile(process.argv[2], function(errin, file) {
     var result;
@@ -13,7 +13,7 @@ fs.readFile(process.argv[2], function(errin, file) {
         throw new Error(errin);
     }
 
-    result = objectify(file);
+    result = transform(file);
 
     if(process.argv[3]) {
         return fs.writeFile(process.argv[3], result, function(errout) {

--- a/browserify.js
+++ b/browserify.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var path = require("path"),
+
+    through = require("through2"),
+    sink    = require("sink-transform"),
+
+    transform = require("./");
+
+module.exports = function browserify(file) {
+    if(path.extname(file) !== ".js") {
+        return through();
+    }
+
+    return sink.str(function(source, done) {
+        this.push(transform(source).toString("utf8"));
+
+        done();
+    });
+};

--- a/index.js
+++ b/index.js
@@ -1,30 +1,12 @@
 "use strict";
 
-var path = require("path"),
-
-    through = require("through2"),
-    sink    = require("sink-transform"),
-    falafel = require("falafel"),
+var falafel = require("falafel"),
 
     objectify = require("./src/objectify");
 
-function transform(source) {
+module.exports = function transform(source) {
     return falafel({
         source      : source,
         ecmaVersion : 6
     }, objectify);
-}
-
-module.exports = function(file) {
-    if(path.extname(file) !== ".js") {
-        return through();
-    }
-
-    return sink.str(function(source, done) {
-        this.push(transform(source).toString());
-
-        done();
-    });
 };
-
-module.exports.objectify = transform;

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "devDependencies": {
     "concat-stream": "^1.5.0",
-    "eslint": "^2.0.0",
-    "eslint-config-arenanet": "^2.0.1",
+    "eslint": "^2.5.3",
+    "eslint-config-arenanet": "^2.0.3",
     "istanbul": "^0.4.0",
     "mithril": "^0.2.0",
     "tap-difflet": "^0.4.0",

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Turn [mithril](http://mithril.js.org) html functions like `m(".fooga")` into sta
 
 for speeeeeed.
 
-Use via CLI, API, or as a [Browserify](http://browserify.org/) transform!
+Use via CLI, API, [Browserify](http://browserify.org/), or [Rollup](http://rollupjs.org)!
 
 Please file an issue if you come across any cases that this doesn't handle, I'd love to improve the number of structures I can rewrite!
 
@@ -51,7 +51,7 @@ Accepts an input file and optional output file. No output file will echo the res
 Accepts a string or buffer, returns a buffer.
 
 ```js
-var objectify = require("mithril-objectify").objectify;
+var objectify = require("mithril-objectify");
 
 console.log(objectify(`m(".fooga.wooga.booga")`);
 
@@ -70,9 +70,27 @@ Use as a browserify transform, either via the CLI or via code.
 ```js
 var build = require("browserify")();
 
-build.transform("mithril-objectify");
+build.transform("mithril-objectify/browserify");
 
 b.add("./client.js");
 
 b.bundle().pipe(process.stdout);
+```
+
+### Rollup
+
+Use as a rollup plugin.
+
+```js
+rollup.rollup({
+    entry   : "./entry.js",
+    plugins : [
+        require("mithril-objectify/rollup")()
+    ]
+})
+.then(function(bundle) {
+    return bundle.write({
+        dest : "./out/source.js"
+    });
+})
 ```

--- a/rollup.js
+++ b/rollup.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var transform = require("./");
+
+module.exports = function rollup() {
+    return {
+        transformBundle : function(code) {
+            return {
+                code : transform(code).toString("utf8")
+            };
+        }
+    };
+};

--- a/test/_parse.js
+++ b/test/_parse.js
@@ -2,7 +2,7 @@
 
 var vm = require("vm"),
     
-    objectify = require("../").objectify;
+    objectify = require("../");
     
 function process(code) {
     return objectify(code).toString("utf8");

--- a/test/_stream.js
+++ b/test/_stream.js
@@ -3,7 +3,7 @@
 module.exports = function(file, contents, done) {
     var Readable  = require("stream").Readable,
         concat    = require("concat-stream"),
-        objectify = require("../"),
+        objectify = require("../browserify"),
         readable  = new Readable(),
         through;
     

--- a/test/tests.js
+++ b/test/tests.js
@@ -156,3 +156,23 @@ test("transform", function(t) {
         );
     });
 });
+
+test("Rollup plugin", function(t) {
+    var r = require("../rollup"),
+        obj;
+
+    t.plan(5);
+
+    t.equal(typeof r, "function");
+
+    obj = r();
+
+    t.equal(typeof obj, "object");
+    t.ok("transformBundle" in obj);
+
+    t.equal(typeof obj.transformBundle, "function");
+    t.deepEqual(
+        obj.transformBundle('m("#fooga")'),
+        { code : '({ tag: "div", attrs: { "id": "fooga" }, children: [] })' }
+    );
+});


### PR DESCRIPTION
Changes default export to be the bare code transformation, adds `/browserify` and `/rollup` for app-specific transforms.