### PR TITLE
Optimize m.component children

### DIFF
--- a/src/mithril.js
+++ b/src/mithril.js
@@ -24,3 +24,6 @@ exports.m = function(node) {
 
 // Is this an invocation of m.trust(...)?
 exports.trust = callExpression.bind(null, "m", "trust");
+
+// Is this an invocation of m.component(...)?
+exports.component = callExpression.bind(null, "m", "component");

--- a/src/valid.js
+++ b/src/valid.js
@@ -47,6 +47,11 @@ exports.children = function(node) {
         return true;
     }
     
+    // m(".fooga", m.component(thing))
+    if(mithril.component(node)) {
+        return true;
+    }
+    
     // m(".fooga", JSON.stringify({}))
     if(json.stringify(node)) {
         return true;

--- a/test/tests.js
+++ b/test/tests.js
@@ -167,6 +167,15 @@ test("m.trust children", function(t) {
     t.end();
 });
 
+test("m.component children", function(t) {
+    t.equal(
+        p.objectify('m("div", m.component(fooga))'),
+        '({ tag: "div", attrs: {  }, children: [ m.component(fooga) ] })'
+    );
+    
+    t.end();
+});
+
 test("Nested m()", function(t) {
     t.deepEqual(
         p('m("div", m("div"))'),


### PR DESCRIPTION
Fixes #28 

This is really straightforward after the work was put in to optimize `m.trust()`, hooray!