### PR TITLE
Ignore attributes with array.prototype transform.

### DIFF
--- a/src/valid.js
+++ b/src/valid.js
@@ -201,8 +201,7 @@ exports.isArg = function(node) {
 
 // Test to see if a node is a passable mithril invocation
 exports.isMithril = function(node) {
-    var first = node.arguments[0],
-        argumentsLength = node.arguments.length;
+    var first = node.arguments[0];
     
     // m()
     if(!exports.isM(node)) {
@@ -223,11 +222,11 @@ exports.isMithril = function(node) {
     }
     
     // m(".fooga")
-    if(argumentsLength === 1) {
+    if(node.arguments.length === 1) {
         return true;
     }
     
-    return Array.prototype.slice.call(node.arguments, 1, argumentsLength).every( function(arg) {
+    return Array.prototype.slice.call(node.arguments, 1, node.arguments.length).every( function(arg) {
         return exports.isArg(arg);
     });
 };

--- a/src/valid.js
+++ b/src/valid.js
@@ -201,7 +201,8 @@ exports.isArg = function(node) {
 
 // Test to see if a node is a passable mithril invocation
 exports.isMithril = function(node) {
-    var first = node.arguments[0];
+    var first = node.arguments[0],
+        argumentsLength = node.arguments.length;
     
     // m()
     if(!exports.isM(node)) {
@@ -222,9 +223,11 @@ exports.isMithril = function(node) {
     }
     
     // m(".fooga")
-    if(node.arguments.length === 1) {
+    if(argumentsLength === 1) {
         return true;
     }
     
-    return exports.isArg(node.arguments[1]);
+    return Array.prototype.slice.call(node.arguments, 1, argumentsLength).every( function(arg) {
+        return exports.isArg(arg);
+    });
 };

--- a/test/advanced.test.js
+++ b/test/advanced.test.js
@@ -91,6 +91,7 @@ describe("mithril-objectify", function() {
             code('m(".fooga", identifier)'),
             'm(".fooga",identifier);'
         );
+        
         assert.equal(
             code('m(".fooga", { class: "x" }, identifier)'),
             'm(".fooga",{class:"x"},identifier);'
@@ -250,6 +251,7 @@ describe("mithril-objectify", function() {
                 'm("div",a.map(function(val){return val;}));'
             );
         });
+        
         it("shouldn't attempt to transform array.prototype methods on unknown targets with attributes", function() {
             assert.equal(
                 code('m("div", {class:"x"}, a.map(function(val) { return val; }))'),

--- a/test/advanced.test.js
+++ b/test/advanced.test.js
@@ -246,6 +246,12 @@ describe("mithril-objectify", function() {
                 'm("div",a.map(function(val){return val;}));'
             );
         });
+        it("shouldn't attempt to transform array.prototype methods on unknown targets with attributes", function() {
+            assert.equal(
+                code('m("div", {class:"x"}, a.map(function(val) { return val; }))'),
+                'm("div",{class:"x"},a.map(function(val){return val;}));'
+            );
+        });
     });
 
     describe("Conditional expression children", function() {

--- a/test/advanced.test.js
+++ b/test/advanced.test.js
@@ -91,6 +91,10 @@ describe("mithril-objectify", function() {
             code('m(".fooga", identifier)'),
             'm(".fooga",identifier);'
         );
+        assert.equal(
+            code('m(".fooga", { class: "x" }, identifier)'),
+            'm(".fooga",{class:"x"},identifier);'
+        );
     });
     
     it("should output correct source maps", function() {


### PR DESCRIPTION
Currently the array prototype check is tripped up (and the vnode is incorrectly optimised) when attributes are given as well, eg:

Works: `m('.asdf',  xyz.map( (x) => x.toUpperCase() ))`
Fails: `m('.asdf', { class: 'x' }, xyz.map( (x) => x.toUpperCase() ))`

This PR fixes this _I think_ (ie, added a test for the new functionality, which passes with this PR; and none of the other tests regress).